### PR TITLE
fix: read allSales route to return all sales without pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *lock*
 .env
+.prettierrc

--- a/src/controllers/salesAd.controller.ts
+++ b/src/controllers/salesAd.controller.ts
@@ -18,13 +18,15 @@ const create = async (req: Request, res: Response): Promise<Response> => {
 };
 
 const readAll = async (req: Request, res: Response): Promise<Response> => {
-    const toListing = res.locals.toListing;
-    const salesAd = await services.salesAd.readAll(toListing);
+    const salesAd = await services.salesAd.readAll();
 
     return res.status(200).json(salesAd);
 };
 
-const filterReadAll = async (req: Request, res: Response): Promise<Response> => {
+const filterReadAll = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
     const filterData = req.body;
     const toListing = res.locals.toListing;
     const salesAd = await services.salesAd.filter(toListing, filterData);
@@ -93,7 +95,7 @@ const salesAd = {
     deleteById,
     createImage,
     updateImageById,
-    filterReadAll
+    filterReadAll,
 };
 
 export default salesAd;

--- a/src/entities/salesAd.entity.ts
+++ b/src/entities/salesAd.entity.ts
@@ -19,7 +19,7 @@ class SalesAd extends BaseEntity {
     @Column({ type: "varchar", length: 255 })
     color: string;
 
-    @Column({ type: "varchar", length: 255})
+    @Column({ type: "varchar", length: 255 })
     engine: string;
 
     @Column({ type: "text" })
@@ -47,7 +47,7 @@ class SalesAd extends BaseEntity {
 @Entity("salesImages", {
     orderBy: {
         created_at: "ASC",
-    }
+    },
 })
 class SalesImages extends BaseEntity {
     @Column({ type: "text" })

--- a/src/routers/salesAd.router.ts
+++ b/src/routers/salesAd.router.ts
@@ -13,7 +13,7 @@ salesAd.post(
     controllers.salesAd.create
 );
 salesAd.post("/seed", seedController);
-salesAd.get("", middlewares.paginateSalesAd, controllers.salesAd.readAll);
+salesAd.get("", controllers.salesAd.readAll);
 salesAd.post(
     "/filter",
     middlewares.paginateSalesAd,

--- a/src/services/salesAd/readAllSalesAd.service.ts
+++ b/src/services/salesAd/readAllSalesAd.service.ts
@@ -1,50 +1,47 @@
 import { SalesAd } from "../../entities/salesAd.entity";
-import {
-    TListArgument,
-    TPaginateSalesAdResponse,
-} from "../../interfaces/salesAd.interface";
+// import {
+//     TListArgument,
+//     TPaginateSalesAdResponse,
+//     TSalesAdResponse,
+// } from "../../interfaces/salesAd.interface";
 import repositories from "../../utils";
 
-const readAll = async (
-    toListing: TListArgument
-): Promise<TPaginateSalesAdResponse> => {
-    let objectToListing = toListing.objectToListing;
+const readAll = async (): Promise<SalesAd[]> => {
+    // let objectToListing = toListing.objectToListing;
 
-    const page = toListing.page;
-    const perPage = toListing.perPage;
+    // const page = toListing.page;
+    // const perPage = toListing.perPage;
 
-    objectToListing = {
-        relations: {
-            salesImages: true,
-        },
-        ...objectToListing,
-    };
+    // objectToListing = {
+    //     relations: {
+    //         salesImages: true,
+    //     },
+    //     ...objectToListing,
+    // };
 
-    let salesAd: SalesAd[] = await repositories.salesAdRepo.find(
-        objectToListing
-    );
+    let salesAd: SalesAd[] = await repositories.salesAdRepo.find();
 
     salesAd = salesAd.map((saleAd) => {
         return { ...saleAd, price: saleAd.price / 100 };
     });
 
-    const salesAdCount: number = await repositories.salesAdRepo.count();
+    // const salesAdCount: number = await repositories.salesAdRepo.count();
 
-    const prevPageUrl: string | null = `http://localhost:3000/salesAd?page=${
-        page - 1
-    }`;
-    const nextPageUrl: string | null = `http://localhost:3000/salesAd?page=${
-        page + 1
-    }`;
+    // const prevPageUrl: string | null = `http://localhost:3000/salesAd?page=${
+    //     page - 1
+    // }`;
+    // const nextPageUrl: string | null = `http://localhost:3000/salesAd?page=${
+    //     page + 1
+    // }`;
 
-    const listSalesAdReturn: TPaginateSalesAdResponse = {
-        prevPage: page <= 1 ? null : prevPageUrl,
-        nextPage: page * perPage >= salesAdCount ? null : nextPageUrl,
-        count: salesAdCount,
-        data: salesAd,
-    };
+    // const listSalesAdReturn: TPaginateSalesAdResponse = {
+    //     prevPage: page <= 1 ? null : prevPageUrl,
+    //     nextPage: page * perPage >= salesAdCount ? null : nextPageUrl,
+    //     count: salesAdCount,
+    //     data: salesAd,
+    // };
 
-    return listSalesAdReturn;
+    return salesAd;
 };
 
 export default readAll;


### PR DESCRIPTION
NÃO ACEITE ESSE REQUEST ANTES DAILY DE 11/08

Mudando a rota do /salesAd para retornar todos as sales, sem paginação. 